### PR TITLE
qualcomm-cdi-generator.py: filter out None for bindmounts

### DIFF
--- a/qualcomm-cdi-generator.py
+++ b/qualcomm-cdi-generator.py
@@ -135,7 +135,7 @@ def main() -> int:
     cdimain = { "cdiVersion": "0.6.0", "kind": "qualcomm.com/device"}
     cdimain["devices"] = render_cdi + video_cdi + dmaheap_cdi + cdsps_cdi + adsps_cdi
     cdimain["containerEdits"] = {"hooks" : [ {"hookname": "createContainer", "path": "/bin/" + hookfilename }],
-                                 "mounts" : mountentries
+                                 "mounts" : list(filter(None, mountentries))
                                 }
 
     # Generate hookscript that runs during createContainer


### PR DESCRIPTION
In case the sizing logic gets it wrong, remove None entries, those result in an invalid CDI, crashing the docker daemon.