### PR TITLE
Fastrpc device detection

### DIFF
--- a/qualcomm-cdi-generator.py
+++ b/qualcomm-cdi-generator.py
@@ -126,10 +126,16 @@ def main() -> int:
     # on the host will be bind mounted automatically
     # Bind mount devicetree model if present
     devicetreefound = 0
+    dtmodelstring = None
     dtmodel = glob.glob("/sys/firmware/devicetree/base/model")
     if dtmodel != None:
         devicetreefound = 1
         dtmodelmount ={"hostPath": "/sys/firmware/devicetree/base/model" , "containerPath": "/run/device-model", "options": ["nosuid", "ro", "bind"]}
+        modeldtnode = open("/sys/firmware/devicetree/base/model", "r")
+        # remove literal Null terminator during read
+        dtmodelstring = str(modeldtnode.read()).replace('\u0000', '')
+        logging.info("Detected $s from devicetree", dtmodelstring)
+        modeldtnode.close()
 
     localfiles = find_devicenodes('/usr/share/*/*/*/*/dsp/')
     mountentries = [None] * (len(localfiles) + devicetreefound)
@@ -140,11 +146,17 @@ def main() -> int:
     if devicetreefound > 0:
         mountentries[mountentry] = dtmodelmount
 
+
+    enventries = []
+    if dtmodelstring is not None:
+        enventries = [ "MACHINE_NAME=" + dtmodelstring ]
+
     # Assemble the complete CDI json
     cdimain = { "cdiVersion": "0.6.0", "kind": "qualcomm.com/device"}
     cdimain["devices"] = render_cdi + video_cdi + dmaheap_cdi + cdsps_cdi + adsps_cdi
     cdimain["containerEdits"] = {"hooks" : [ {"hookname": "createContainer", "path": "/bin/" + hookfilename }],
                                  "mounts" : list(filter(None, mountentries))
+                                 "env" : enventries
                                 }
 
     # Generate hookscript that runs during createContainer

--- a/qualcomm-cdi-generator.py
+++ b/qualcomm-cdi-generator.py
@@ -124,12 +124,21 @@ def main() -> int:
     # tightly coupled to the files loaded by the in-kernel firmware
     # loader. To lower the chance of a mismatch, Hexagon binaries found
     # on the host will be bind mounted automatically
+    # Bind mount devicetree model if present
+    devicetreefound = 0
+    dtmodel = glob.glob("/sys/firmware/devicetree/base/model")
+    if dtmodel != None:
+        devicetreefound = 1
+        dtmodelmount ={"hostPath": "/sys/firmware/devicetree/base/model" , "containerPath": "/run/device-model", "options": ["nosuid", "ro", "bind"]}
+
     localfiles = find_devicenodes('/usr/share/*/*/*/*/dsp/')
-    mountentries = [None] * len(localfiles)
+    mountentries = [None] * (len(localfiles) + devicetreefound)
     mountentry = 0
     for localfile in localfiles:
         mountentries[mountentry] ={"hostPath": localfile , "containerPath": localfile, "options": ["nosuid", "ro", "bind"]}
         mountentry += 1
+    if devicetreefound > 0:
+        mountentries[mountentry] = dtmodelmount
 
     # Assemble the complete CDI json
     cdimain = { "cdiVersion": "0.6.0", "kind": "qualcomm.com/device"}


### PR DESCRIPTION
Fastrpc needs to know the model for it to load the proper config since it can't autodetect the DSPs at runtime. Provide 2 ways to do this:

1. MACHINE_NAME environment variable, needs fastrpc newer than 1.0.4
2. Bind mount devicetree model name to /run, this needs a custom build which sets `-DMACHINE_NAME_PATH` to the /run location.