### PR TITLE
qualcomm-cdi-generator.py: add missing comma after merge conflict resolution

### DIFF
--- a/qualcomm-cdi-generator.py
+++ b/qualcomm-cdi-generator.py
@@ -155,7 +155,7 @@ def main() -> int:
     cdimain = { "cdiVersion": "0.6.0", "kind": "qualcomm.com/device"}
     cdimain["devices"] = render_cdi + video_cdi + dmaheap_cdi + cdsps_cdi + adsps_cdi
     cdimain["containerEdits"] = {"hooks" : [ {"hookname": "createContainer", "path": "/bin/" + hookfilename }],
-                                 "mounts" : list(filter(None, mountentries))
+                                 "mounts" : list(filter(None, mountentries)),
                                  "env" : enventries
                                 }
 


### PR DESCRIPTION
The manual merge conflict resolution missed a comma, add it in.

Fixes:
```python
  File "/root/qualcomm-CDI-generator/./qualcomm-cdi-generator.py", line 158
    "mounts" : list(filter(None, mountentries))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```