### PR TITLE
packaging: add setuptools based packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 output
+dist/
+build/
+*.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,20 @@
+[metadata]
+name = qualcomm-cdi-generator
+version = 0.4
+description = Qualcomm CDI device generator for container runtimes
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = BSD-3-Clause
+url = https://github.com/qualcomm-linux/qualcomm-CDI-generator
+python_requires = >=3.8
+
+[options]
+py_modules =
+
+[options.data_files]
+sbin =
+    qualcomm-cdi-generator.py
+lib/systemd/system =
+    qualcomm-cdi-generator.service
+lib/systemd/system-preset =
+    10-qualcomm-cdi-generator.preset


### PR DESCRIPTION
Adds pyproject.toml and setup.cfg to provide setuptools-based packaging alongside the existing meson build. Installs qualcomm-cdi-generator.py to sbin/, the systemd unit to lib/systemd/system/, and the preset to lib/systemd/system-preset/, mirroring the meson install layout.

All package metadata lives in setup.cfg [metadata] so that pybuild's --no-isolation build (system setuptools 59.6, predating pyproject.toml [project] support) can resolve the package name and version correctly.

No new runtime dependencies: the script uses only Python stdlib modules. Also adds dist/, build/, and *.egg-info/ to .gitignore.