### PR TITLE
stale-issues: raise auto-close threshold from 30 to 90 days

### DIFF
--- a/.github/workflows/Readme.md
+++ b/.github/workflows/Readme.md
@@ -3,4 +3,4 @@ This folder contains workflows that are helpful for maintaining a smooth and sec
 
 Workflows:
 1. `qcom-preflight-checks.yml` - This workflow runs several preflight checks, including copyight, email, repolinter, and security checks.  See [qualcomm/qcom-actions](https://github.com/qualcomm/qcom-actions)
-2. `stale-issues.yaml` - This workflow will periodically run every 30 days to check for stalled issues and PRs. If the workflow detects any stalled issues and/or PRs, it will automatically leave just a comment to draw attention.
+2. `stale-issues.yaml` - This workflow will periodically run every 90 days to check for stalled issues and PRs. If the workflow detects any stalled issues and/or PRs, it will automatically leave just a comment to draw attention.

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -13,11 +13,11 @@ jobs:
     steps:
     - uses: actions/stale@v10
       with:
-        stale-issue-message: 'This issue has been marked as stale due to 30 days of inactivity. To prevent automatic closure in 5 days, remove the stale label or add a comment. You can reopen a closed issue at any time.'
-        stale-pr-message: 'This pull request has been marked as stale due to 30 days of inactivity. To prevent automatic closure in 5 days, remove the stale label or add a comment. You can reopen a closed pull request at any time.'
+        stale-issue-message: 'This issue has been marked as stale due to 90 days of inactivity. To prevent automatic closure in 5 days, remove the stale label or add a comment. You can reopen a closed issue at any time.'
+        stale-pr-message: 'This pull request has been marked as stale due to 90 days of inactivity. To prevent automatic closure in 5 days, remove the stale label or add a comment. You can reopen a closed pull request at any time.'
         exempt-issue-labels: bug,enhancement
         exempt-pr-labels: bug,enhancement
-        days-before-stale: 30
+        days-before-stale: 90
         days-before-close: 5
         remove-stale-when-updated: true
         remove-issue-stale-when-updated: true


### PR DESCRIPTION
## Summary
- Raise `days-before-stale` from 30 to 90 days in the stale issues/PRs workflow, and update the stale message text and Readme.md description to match.

## Test plan
- [ ] Confirm the workflow still runs on schedule and applies the stale label only after 90 days of inactivity