### PR TITLE
qualcomm-cdi-generator.py: CDI spec conformance and --classes fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ output
 dist/
 build/
 *.egg-info/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Example `qualcomm-gpu.json`:
     }
   ],
   "containerEdits": {
-    "hooks": [ { "hookname": "createContainer", "path": "/bin/vendorhook" } ],
+    "hooks": [ { "hookName": "createContainer", "path": "/bin/vendorhook" } ],
     "env": [ "MACHINE_NAME=Qualcomm Technologies, Inc. Robotics RB3gen2" ]
   }
 }

--- a/qualcomm-cdi-generator.py
+++ b/qualcomm-cdi-generator.py
@@ -264,6 +264,19 @@ def main() -> int:
     dynamiccdidir = Path(destdir).joinpath('run/cdi')
     cdifilename_stem = Path(cdifilename).stem
     cdifilename_suffix = Path(cdifilename).suffix
+
+    # Older versions wrote a single monolithic CDI file (e.g. qualcomm.json); we
+    # now write one file per device class (qualcomm-gpu.json, ...). Remove any
+    # leftover monolithic file so it cannot define conflicting/stale devices
+    # alongside the per-class files.
+    legacy_cdi = dynamiccdidir.joinpath(cdifilename)
+    if legacy_cdi.is_file():
+        if args.dry_run:
+            logging.info("Dry run: would remove old style monolithic CDI %s", legacy_cdi)
+        else:
+            logging.warning("Old style monolithic CDI detected, removing %s", legacy_cdi)
+            legacy_cdi.unlink()
+
     for cdiclass, devices in cdi_sections:
         if not devices:
             logging.debug("Skipping CDI file for '%s': no devices", cdiclass)

--- a/qualcomm-cdi-generator.py
+++ b/qualcomm-cdi-generator.py
@@ -67,6 +67,17 @@ def generate_devicenodes_cdi(nickname, filesglob):
         def is_sibling(node):
             return node.endswith('-secure') and node[:-len('-secure')] in filesglob_set
 
+        def node_paths(node: str) -> list[dict]:
+            # deviceNodes entries for one node: the node itself, plus its -secure
+            # sibling when this is a cdsp/adsp node and that sibling is present.
+            paths = [{"path": node}]
+            if node.endswith(('cdsp', 'adsp')):
+                securepath = node + "-secure"
+                if securepath in filesglob_set:
+                    logging.debug("DSP node detected, adding -secure variant for %s", node)
+                    paths.append({"path": securepath})
+            return paths
+
         # Count only nodes that will produce their own CDI entry
         effective_count = sum(1 for n in filesglob if not is_sibling(n))
 
@@ -75,18 +86,7 @@ def generate_devicenodes_cdi(nickname, filesglob):
         for devicenode in sorted(filesglob):
             if is_sibling(devicenode):
                 continue
-            device_path = {"path": devicenode}
-            # cdsp/adsp may have a -secure sibling node
-            if str(devicenode).endswith('cdsp') or str(devicenode).endswith('adsp'):
-                securepath = devicenode + "-secure"
-                if securepath in filesglob_set:
-                    logging.debug("DSP node detected, adding regular and -secure variants")
-                    device_pathlist = { "deviceNodes": [ device_path, {"path": securepath} ] }
-                else:
-                    logging.debug("DSP node detected, -secure variant not present, skipping")
-                    device_pathlist = { "deviceNodes": [ device_path ] }
-            else:
-                device_pathlist = { "deviceNodes": [ device_path ] }
+            device_pathlist = { "deviceNodes": node_paths(devicenode) }
             cdi_index = get_devicenode_index(devicenode)
             # If there's only one match *and* it doesn't have its own index, don't add the '0' index
             if effective_count == 1 and cdi_index is None:
@@ -109,12 +109,8 @@ def generate_devicenodes_cdi(nickname, filesglob):
         for devicenode in sorted(filesglob):
             if is_sibling(devicenode):
                 continue
-            device_paths.append({"path": devicenode})
-            # Mirror the per-device special case so cdsp-secure/adsp-secure is also in :all
-            if str(devicenode).endswith('cdsp') or str(devicenode).endswith('adsp'):
-                securepath = devicenode + "-secure"
-                if securepath in filesglob_set:
-                    device_paths.append({"path": securepath})
+            # Reuse the per-device logic so cdsp-secure/adsp-secure is also in :all
+            device_paths.extend(node_paths(devicenode))
         device_pathlist = { "deviceNodes":  device_paths  }
         device_entrys = { "name": nickname+":all", "containerEdits": device_pathlist }
         logging.debug("CDI catch-all entry: %s", device_entrys)

--- a/qualcomm-cdi-generator.py
+++ b/qualcomm-cdi-generator.py
@@ -197,7 +197,16 @@ def main() -> int:
 
     # Host-side helpers
     # TODO: generate helper scripts based the results of the above probes
-    allnodes = rendernodes + videonodes + dmaheaps + cdsps + adsps
+    # Only chmod nodes for classes that are actually being generated, so
+    # --classes keeps the hook script in sync with the written CDI files.
+    nodes_by_class = {
+        'gpu':          rendernodes,
+        'v4l2':         videonodes,
+        'dmaheap':      dmaheaps,
+        'fastrpc-cdsp': cdsps,
+        'fastrpc-adsp': adsps,
+    }
+    allnodes = [n for c, nodes in nodes_by_class.items() if c in enabled_classes for n in nodes]
     logging.info("Total nodes aggregated for hook: %d", len(allnodes))
 
     # Bind mounts into container

--- a/qualcomm-cdi-generator.py
+++ b/qualcomm-cdi-generator.py
@@ -4,6 +4,14 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
+# This tool generates Container Device Interface (CDI) specification files as
+# defined by the CNCF Container Device Interface project:
+#
+#   https://github.com/cncf-tags/container-device-interface
+#
+# The generated JSON files follow the CDI spec format (see the CDI_VERSION
+# below) and can be validated with the upstream 'cdi' tool from that project.
+
 import glob
 import json
 from pathlib import Path
@@ -15,6 +23,14 @@ import os
 import argparse
 
 known_classes = ['gpu', 'v4l2', 'dmaheap', 'fastrpc-cdsp', 'fastrpc-adsp']
+
+# CDI specification version emitted in every generated spec file. See the CNCF
+# Container Device Interface project for the format definition:
+# https://github.com/cncf-tags/container-device-interface
+CDI_VERSION = "0.6.0"
+
+# CDI vendor namespace prefixed to every generated 'kind' (e.g. qualcomm.com/gpu)
+CDI_VENDOR = "qualcomm.com"
 
 def setup_logging(verbosity: int) -> None:
     level = logging.WARNING
@@ -112,6 +128,34 @@ def get_devicenode_index(nodename):
     # Extract a trailing integer from the node name (e.g. 128 from 'renderD128')
     nodeindex = re.search(r'\d+$', nodename)
     return int(nodeindex.group()) if nodeindex else None
+
+def build_cdi_spec(cdiclass, devices, hookfilename, enventries, mountentries):
+    """Assemble a single CDI specification dict for one device class.
+
+    The returned structure follows the CDI spec format defined by the CNCF
+    Container Device Interface project:
+        https://github.com/cncf-tags/container-device-interface
+
+    cdiclass:     device class name, suffixed onto CDI_VENDOR for the 'kind'
+    devices:      list of CDI device entries (as built by generate_devicenodes_cdi)
+    hookfilename: basename of the createContainer hook script under /bin
+    enventries:   list of "KEY=value" strings added to containerEdits.env
+    mountentries: list of mount dicts; only attached for fastrpc classes
+
+    This function is pure (no filesystem access) so the generated spec can be
+    validated by the upstream 'cdi' tool in the unit tests.
+    """
+    cdi = {"cdiVersion": CDI_VERSION, "kind": CDI_VENDOR + "/" + cdiclass}
+    cdi["devices"] = devices
+    container_edits = {"hooks": [{"hookname": "createContainer", "path": "/bin/" + hookfilename}],
+                       "env": enventries}
+    # Only bind-mount DSP firmware and devicetree for fastrpc device classes,
+    # as those are the only classes that use Hexagon binaries
+    if "fastrpc" in cdiclass:
+        # filter(None, ...) strips any None placeholders left in the pre-allocated list
+        container_edits["mounts"] = list(filter(None, mountentries))
+    cdi["containerEdits"] = container_edits
+    return cdi
 
 def main() -> int:
     args = parse_args()
@@ -228,16 +272,7 @@ def main() -> int:
         if not devices:
             logging.debug("Skipping CDI file for '%s': no devices", cdiclass)
             continue
-        cdi = {"cdiVersion": "0.6.0", "kind": "qualcomm.com/" + cdiclass}
-        cdi["devices"] = devices
-        container_edits = {"hooks": [{"hookname": "createContainer", "path": "/bin/" + hookfilename}],
-                           "env": enventries}
-        # Only bind-mount DSP firmware and devicetree for fastrpc device classes,
-        # as those are the only classes that use Hexagon binaries
-        if "fastrpc" in cdiclass:
-            # filter(None, ...) strips any None placeholders left in the pre-allocated list
-            container_edits["mounts"] = list(filter(None, mountentries))
-        cdi["containerEdits"] = container_edits
+        cdi = build_cdi_spec(cdiclass, devices, hookfilename, enventries, mountentries)
         section_filename = "%s-%s%s" % (cdifilename_stem, cdiclass, cdifilename_suffix)
         cdipath = dynamiccdidir.joinpath(section_filename)
         if args.dry_run:

--- a/qualcomm-cdi-generator.py
+++ b/qualcomm-cdi-generator.py
@@ -147,7 +147,7 @@ def build_cdi_spec(cdiclass, devices, hookfilename, enventries, mountentries):
     """
     cdi = {"cdiVersion": CDI_VERSION, "kind": CDI_VENDOR + "/" + cdiclass}
     cdi["devices"] = devices
-    container_edits = {"hooks": [{"hookname": "createContainer", "path": "/bin/" + hookfilename}],
+    container_edits = {"hooks": [{"hookName": "createContainer", "path": "/bin/" + hookfilename}],
                        "env": enventries}
     # Only bind-mount DSP firmware and devicetree for fastrpc device classes,
     # as those are the only classes that use Hexagon binaries

--- a/tests/test_cdi_validation.py
+++ b/tests/test_cdi_validation.py
@@ -29,6 +29,7 @@ or point the suite at a freshly built tool:
 
 import importlib.util
 import json
+import logging
 import os
 import shutil
 import subprocess
@@ -65,6 +66,52 @@ def _find_cdi_tool():
 
 gen = _load_generator()
 CDI_TOOL = _find_cdi_tool()
+
+
+# Device probes returned by a fully-populated synthetic host; used to drive
+# main() deterministically regardless of the hardware the tests run on.
+FAKE_NODES = {
+    "/dev/dri/renderD*": ["/dev/dri/renderD128"],
+    "/dev/video*": ["/dev/video0", "/dev/video1"],
+    "/dev/dma_heap/*system": ["/dev/dma_heap/system"],
+    "/dev/fastrpc-cdsp*": ["/dev/fastrpc-cdsp", "/dev/fastrpc-cdsp-secure"],
+    "/dev/fastrpc-adsp*": ["/dev/fastrpc-adsp"],
+    "/usr/share/*/*/*/*/dsp/": [],
+}
+
+
+def run_generator(extra_argv, fake_nodes=FAKE_NODES):
+    """Run main() with synthetic device discovery into a fresh argv.
+
+    find_devicenodes is replaced with controlled node lists and the direct
+    glob.glob() devicetree probe is stubbed empty, so the run does not depend
+    on the host hardware. Returns main()'s exit code.
+    """
+    real_find = gen.find_devicenodes
+
+    def fake_find(deviceglob):
+        # Controlled lists for known probes; fall back to the real glob for
+        # anything unexpected so a typo surfaces as a test error.
+        return list(fake_nodes[deviceglob]) if deviceglob in fake_nodes \
+            else real_find(deviceglob)
+
+    real_glob = gen.glob.glob
+
+    def fake_glob(pattern, *args, **kwargs):
+        if pattern == "/sys/firmware/devicetree/base/model":
+            return []
+        return real_glob(pattern, *args, **kwargs)
+
+    with mock.patch.object(gen, "find_devicenodes", fake_find), \
+            mock.patch.object(gen.glob, "glob", fake_glob), \
+            mock.patch.object(sys, "argv", ["qualcomm-cdi-generator.py"] + extra_argv):
+        # main() calls setup_logging(), which would print the generator's log
+        # lines to the test console; keep the suite output clean by muting it.
+        logging.disable(logging.CRITICAL)
+        try:
+            return gen.main()
+        finally:
+            logging.disable(logging.NOTSET)
 
 
 class StructuralTests(unittest.TestCase):
@@ -121,6 +168,35 @@ class StructuralTests(unittest.TestCase):
         paths = [n["path"] for n in parent["containerEdits"]["deviceNodes"]]
         self.assertIn("/dev/fastrpc-cdsp", paths)
         self.assertIn("/dev/fastrpc-cdsp-secure", paths)
+
+    def test_legacy_monolithic_cdi_removed(self):
+        # An old single-file qualcomm.json left in /run/cdi must be removed so it
+        # cannot define stale/conflicting devices alongside the per-class files.
+        with tempfile.TemporaryDirectory() as d:
+            cdi_dir = Path(d) / "run" / "cdi"
+            cdi_dir.mkdir(parents=True)
+            legacy = cdi_dir / "qualcomm.json"
+            legacy.write_text('{"cdiVersion": "0.6.0", "kind": "qualcomm.com/legacy"}')
+
+            rc = run_generator(["-d", d])
+
+            self.assertEqual(rc, 0)
+            self.assertFalse(legacy.exists(), "legacy monolithic CDI was not removed")
+            # The per-class files use a different name and must still be written.
+            self.assertTrue((cdi_dir / "qualcomm-gpu.json").is_file())
+
+    def test_legacy_monolithic_cdi_preserved_on_dry_run(self):
+        # A dry run reports what it would remove but must not touch the file.
+        with tempfile.TemporaryDirectory() as d:
+            cdi_dir = Path(d) / "run" / "cdi"
+            cdi_dir.mkdir(parents=True)
+            legacy = cdi_dir / "qualcomm.json"
+            legacy.write_text("{}")
+
+            rc = run_generator(["-d", d, "-n"])
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(legacy.exists(), "dry run must not remove the legacy CDI")
 
 
 @unittest.skipIf(CDI_TOOL is None,
@@ -198,37 +274,8 @@ class ValidationTests(unittest.TestCase):
     def test_full_generator_run_validates(self):
         # Drive main() end to end with synthetic device discovery so every class
         # is produced, then validate the whole set of written files together.
-        fake_nodes = {
-            "/dev/dri/renderD*": ["/dev/dri/renderD128"],
-            "/dev/video*": ["/dev/video0", "/dev/video1"],
-            "/dev/dma_heap/*system": ["/dev/dma_heap/system"],
-            "/dev/fastrpc-cdsp*": ["/dev/fastrpc-cdsp", "/dev/fastrpc-cdsp-secure"],
-            "/dev/fastrpc-adsp*": ["/dev/fastrpc-adsp"],
-            "/usr/share/*/*/*/*/dsp/": [],
-        }
-
-        real_find = gen.find_devicenodes
-
-        def fake_find(deviceglob):
-            # Return controlled node lists for the known probes; fall back to the
-            # real glob for anything unexpected so a typo surfaces as a test error.
-            return list(fake_nodes[deviceglob]) if deviceglob in fake_nodes \
-                else real_find(deviceglob)
-
-        real_glob = gen.glob.glob
-
-        def fake_glob(pattern, *args, **kwargs):
-            # main() probes the devicetree model directly via glob.glob(); keep it
-            # empty so the run does not depend on the host's devicetree.
-            if pattern == "/sys/firmware/devicetree/base/model":
-                return []
-            return real_glob(pattern, *args, **kwargs)
-
-        with tempfile.TemporaryDirectory() as d, \
-                mock.patch.object(gen, "find_devicenodes", fake_find), \
-                mock.patch.object(gen.glob, "glob", fake_glob), \
-                mock.patch.object(sys, "argv", ["qualcomm-cdi-generator.py", "-d", d]):
-            rc = gen.main()
+        with tempfile.TemporaryDirectory() as d:
+            rc = run_generator(["-d", d])
 
             self.assertEqual(rc, 0)
             cdi_dir = Path(d) / "run" / "cdi"

--- a/tests/test_cdi_validation.py
+++ b/tests/test_cdi_validation.py
@@ -198,6 +198,39 @@ class StructuralTests(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertTrue(legacy.exists(), "dry run must not remove the legacy CDI")
 
+    def _hook_nodes(self, destdir):
+        """Return the list of node paths chmod'd by the generated hook script."""
+        text = (Path(destdir) / "bin" / "vendorhook").read_text()
+        for line in text.splitlines():
+            if line.startswith("for node in"):
+                # "for node in <paths...> ; do"
+                return line[len("for node in"):].split(";")[0].split()
+        return []
+
+    def test_classes_filters_hook_nodes(self):
+        # --classes must scope the hook's chmod list to the selected classes,
+        # keeping the hook in sync with the generated CDI files.
+        with tempfile.TemporaryDirectory() as d:
+            rc = run_generator(["-d", d, "--classes", "fastrpc-cdsp"])
+            self.assertEqual(rc, 0)
+            nodes = self._hook_nodes(d)
+            self.assertEqual(sorted(nodes),
+                             ["/dev/fastrpc-cdsp", "/dev/fastrpc-cdsp-secure"])
+
+    def test_default_hook_includes_all_nodes(self):
+        # Without --classes the hook covers every discovered node.
+        with tempfile.TemporaryDirectory() as d:
+            rc = run_generator(["-d", d])
+            self.assertEqual(rc, 0)
+            nodes = set(self._hook_nodes(d))
+            self.assertEqual(nodes, {
+                "/dev/dri/renderD128",
+                "/dev/video0", "/dev/video1",
+                "/dev/dma_heap/system",
+                "/dev/fastrpc-cdsp", "/dev/fastrpc-cdsp-secure",
+                "/dev/fastrpc-adsp",
+            })
+
 
 @unittest.skipIf(CDI_TOOL is None,
                  "cdi tool not found (set CDI_TOOL or put 'cdi' on PATH)")

--- a/tests/test_cdi_validation.py
+++ b/tests/test_cdi_validation.py
@@ -79,7 +79,7 @@ class StructuralTests(unittest.TestCase):
         spec = gen.build_cdi_spec("gpu", [], "myhook", [], [])
         hooks = spec["containerEdits"]["hooks"]
         self.assertEqual(len(hooks), 1)
-        self.assertEqual(hooks[0]["hookname"], "createContainer")
+        self.assertEqual(hooks[0]["hookName"], "createContainer")
         self.assertEqual(hooks[0]["path"], "/bin/myhook")
 
     def test_mounts_only_for_fastrpc(self):

--- a/tests/test_cdi_validation.py
+++ b/tests/test_cdi_validation.py
@@ -1,0 +1,261 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+"""Stand-alone unit tests for the Qualcomm CDI generator.
+
+The tests are split in two groups:
+
+  * Structural tests that exercise the spec-building helpers directly and need
+    no external tooling.
+  * Validation tests that write generated CDI JSON files and run the upstream
+    'cdi' tool from the CNCF Container Device Interface project to confirm the
+    output conforms to the CDI specification:
+        https://github.com/cncf-tags/container-device-interface
+
+The 'cdi' tool is located via the CDI_TOOL environment variable (an absolute
+path to the binary) or, failing that, the first 'cdi' found on PATH. When the
+tool cannot be found the validation tests are skipped rather than failed, so
+the suite remains usable in environments where 'cdi' is not installed.
+
+Run from the repository root with:
+
+    python3 -m unittest discover -s tests -v
+
+or point the suite at a freshly built tool:
+
+    CDI_TOOL=/path/to/cdi python3 -m unittest discover -s tests -v
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+def _load_generator():
+    """Import the generator script as a module despite its hyphenated name."""
+    repo_root = Path(__file__).resolve().parent.parent
+    script = repo_root / "qualcomm-cdi-generator.py"
+    if not script.is_file():
+        raise FileNotFoundError("generator script not found at %s" % script)
+    spec = importlib.util.spec_from_file_location("qualcomm_cdi_generator", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _find_cdi_tool():
+    """Return the path to the 'cdi' validation tool, or None if unavailable."""
+    env_tool = os.environ.get("CDI_TOOL")
+    if env_tool:
+        # An explicitly configured tool that does not exist is a hard error:
+        # the caller asked for a specific binary and we should not silently skip.
+        if not (os.path.isfile(env_tool) and os.access(env_tool, os.X_OK)):
+            raise FileNotFoundError("CDI_TOOL=%s is not an executable file" % env_tool)
+        return env_tool
+    return shutil.which("cdi")
+
+
+gen = _load_generator()
+CDI_TOOL = _find_cdi_tool()
+
+
+class StructuralTests(unittest.TestCase):
+    """Tests for the pure spec-building helpers; no external tooling needed."""
+
+    def test_kind_and_version(self):
+        spec = gen.build_cdi_spec("gpu", [], "vendorhook", [], [])
+        self.assertEqual(spec["cdiVersion"], gen.CDI_VERSION)
+        self.assertEqual(spec["kind"], gen.CDI_VENDOR + "/gpu")
+
+    def test_hook_is_added(self):
+        spec = gen.build_cdi_spec("gpu", [], "myhook", [], [])
+        hooks = spec["containerEdits"]["hooks"]
+        self.assertEqual(len(hooks), 1)
+        self.assertEqual(hooks[0]["hookname"], "createContainer")
+        self.assertEqual(hooks[0]["path"], "/bin/myhook")
+
+    def test_mounts_only_for_fastrpc(self):
+        mounts = [{"hostPath": "/x", "containerPath": "/x", "options": ["ro", "bind"]}]
+        gpu = gen.build_cdi_spec("gpu", [], "vendorhook", [], mounts)
+        self.assertNotIn("mounts", gpu["containerEdits"])
+        cdsp = gen.build_cdi_spec("fastrpc-cdsp", [], "vendorhook", [], mounts)
+        self.assertEqual(cdsp["containerEdits"]["mounts"], mounts)
+
+    def test_mount_none_placeholders_filtered(self):
+        # main() pre-allocates the mount list with None placeholders; build_cdi_spec
+        # must strip them so the emitted spec never contains null mount entries.
+        mounts = [None, {"hostPath": "/x", "containerPath": "/x", "options": ["ro", "bind"]}, None]
+        cdsp = gen.build_cdi_spec("fastrpc-cdsp", [], "vendorhook", [], mounts)
+        self.assertEqual(len(cdsp["containerEdits"]["mounts"]), 1)
+        self.assertNotIn(None, cdsp["containerEdits"]["mounts"])
+
+    def test_env_passthrough(self):
+        env = ["MACHINE_NAME=Synthetic Board"]
+        spec = gen.build_cdi_spec("fastrpc-adsp", [], "vendorhook", env, [])
+        self.assertEqual(spec["containerEdits"]["env"], env)
+
+    def test_single_unnamed_node_has_no_index(self):
+        # A lone node without a trailing number should not gain a '0' suffix.
+        devices = gen.generate_devicenodes_cdi("dmaheap-system", ["/dev/dma_heap/system"])
+        names = [d["name"] for d in devices]
+        self.assertIn("dmaheap-system", names)
+        self.assertIn("dmaheap-system:all", names)
+
+    def test_secure_sibling_folded_into_parent(self):
+        # /dev/fastrpc-cdsp-secure must ride along with its non-secure parent
+        # rather than producing an independent top-level entry.
+        nodes = ["/dev/fastrpc-cdsp", "/dev/fastrpc-cdsp-secure"]
+        devices = gen.generate_devicenodes_cdi("fastrpc-cdsp", nodes)
+        named = {d["name"]: d for d in devices}
+        # No entry should be named after the -secure node directly.
+        self.assertNotIn("fastrpc-cdsp-secure", named)
+        parent = named["fastrpc-cdsp"]
+        paths = [n["path"] for n in parent["containerEdits"]["deviceNodes"]]
+        self.assertIn("/dev/fastrpc-cdsp", paths)
+        self.assertIn("/dev/fastrpc-cdsp-secure", paths)
+
+
+@unittest.skipIf(CDI_TOOL is None,
+                 "cdi tool not found (set CDI_TOOL or put 'cdi' on PATH)")
+class ValidationTests(unittest.TestCase):
+    """Validate generated CDI JSON with the upstream 'cdi' tool.
+
+    'cdi validate' checks each spec against the CDI JSON schema; it does not
+    require the referenced device nodes to exist, so synthetic node lists give
+    deterministic results independent of the host hardware.
+    """
+
+    def _validate_dir(self, spec_dir):
+        """Run 'cdi validate' against spec_dir; return (returncode, output)."""
+        proc = subprocess.run(
+            [CDI_TOOL, "validate", "--spec-dirs", str(spec_dir)],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+        return proc.returncode, proc.stdout
+
+    def _write_spec(self, spec_dir, cdiclass, spec):
+        path = Path(spec_dir) / ("qualcomm-%s.json" % cdiclass)
+        with open(path, "w") as f:
+            json.dump(spec, f)
+        return path
+
+    def _assert_valid(self, spec_dir):
+        rc, out = self._validate_dir(spec_dir)
+        self.assertEqual(rc, 0, "cdi validate reported errors:\n%s" % out)
+
+    def test_gpu_spec_validates(self):
+        nodes = ["/dev/dri/renderD128", "/dev/dri/renderD129"]
+        devices = gen.generate_devicenodes_cdi("renderD", nodes)
+        spec = gen.build_cdi_spec("gpu", devices, "vendorhook", [], [])
+        with tempfile.TemporaryDirectory() as d:
+            self._write_spec(d, "gpu", spec)
+            self._assert_valid(d)
+
+    def test_v4l2_spec_validates(self):
+        nodes = ["/dev/video%d" % i for i in range(5)]
+        devices = gen.generate_devicenodes_cdi("video", nodes)
+        spec = gen.build_cdi_spec("v4l2", devices, "vendorhook", [], [])
+        with tempfile.TemporaryDirectory() as d:
+            self._write_spec(d, "v4l2", spec)
+            self._assert_valid(d)
+
+    def test_dmaheap_spec_validates(self):
+        devices = gen.generate_devicenodes_cdi("dmaheap-system", ["/dev/dma_heap/system"])
+        spec = gen.build_cdi_spec("dmaheap", devices, "vendorhook", [], [])
+        with tempfile.TemporaryDirectory() as d:
+            self._write_spec(d, "dmaheap", spec)
+            self._assert_valid(d)
+
+    def test_fastrpc_spec_with_mounts_and_env_validates(self):
+        nodes = ["/dev/fastrpc-cdsp", "/dev/fastrpc-cdsp-secure"]
+        devices = gen.generate_devicenodes_cdi("fastrpc-cdsp", nodes)
+        mounts = [{"hostPath": "/usr/share/foo/bar/1.0/aarch64/dsp/",
+                   "containerPath": "/usr/share/foo/bar/1.0/aarch64/dsp/",
+                   "options": ["nosuid", "ro", "bind"]}]
+        env = ["MACHINE_NAME=Synthetic Board"]
+        spec = gen.build_cdi_spec("fastrpc-cdsp", devices, "vendorhook", env, mounts)
+        with tempfile.TemporaryDirectory() as d:
+            self._write_spec(d, "fastrpc-cdsp", spec)
+            self._assert_valid(d)
+
+    def test_fastrpc_spec_with_empty_mounts_validates(self):
+        # When no DSP firmware is found the generator still emits "mounts": [].
+        devices = gen.generate_devicenodes_cdi("fastrpc-adsp", ["/dev/fastrpc-adsp"])
+        spec = gen.build_cdi_spec("fastrpc-adsp", devices, "vendorhook", [], [])
+        with tempfile.TemporaryDirectory() as d:
+            self._write_spec(d, "fastrpc-adsp", spec)
+            self._assert_valid(d)
+
+    def test_full_generator_run_validates(self):
+        # Drive main() end to end with synthetic device discovery so every class
+        # is produced, then validate the whole set of written files together.
+        fake_nodes = {
+            "/dev/dri/renderD*": ["/dev/dri/renderD128"],
+            "/dev/video*": ["/dev/video0", "/dev/video1"],
+            "/dev/dma_heap/*system": ["/dev/dma_heap/system"],
+            "/dev/fastrpc-cdsp*": ["/dev/fastrpc-cdsp", "/dev/fastrpc-cdsp-secure"],
+            "/dev/fastrpc-adsp*": ["/dev/fastrpc-adsp"],
+            "/usr/share/*/*/*/*/dsp/": [],
+        }
+
+        real_find = gen.find_devicenodes
+
+        def fake_find(deviceglob):
+            # Return controlled node lists for the known probes; fall back to the
+            # real glob for anything unexpected so a typo surfaces as a test error.
+            return list(fake_nodes[deviceglob]) if deviceglob in fake_nodes \
+                else real_find(deviceglob)
+
+        real_glob = gen.glob.glob
+
+        def fake_glob(pattern, *args, **kwargs):
+            # main() probes the devicetree model directly via glob.glob(); keep it
+            # empty so the run does not depend on the host's devicetree.
+            if pattern == "/sys/firmware/devicetree/base/model":
+                return []
+            return real_glob(pattern, *args, **kwargs)
+
+        with tempfile.TemporaryDirectory() as d, \
+                mock.patch.object(gen, "find_devicenodes", fake_find), \
+                mock.patch.object(gen.glob, "glob", fake_glob), \
+                mock.patch.object(sys, "argv", ["qualcomm-cdi-generator.py", "-d", d]):
+            rc = gen.main()
+
+            self.assertEqual(rc, 0)
+            cdi_dir = Path(d) / "run" / "cdi"
+            written = sorted(p.name for p in cdi_dir.glob("*.json"))
+            self.assertEqual(written, [
+                "qualcomm-dmaheap.json",
+                "qualcomm-fastrpc-adsp.json",
+                "qualcomm-fastrpc-cdsp.json",
+                "qualcomm-gpu.json",
+                "qualcomm-v4l2.json",
+            ])
+            self._assert_valid(cdi_dir)
+
+    def test_malformed_spec_is_rejected(self):
+        # Negative control: confirm the validator actually fails on a bad spec,
+        # so a passing run above means something.
+        with tempfile.TemporaryDirectory() as d:
+            bad = Path(d) / "qualcomm-bad.json"
+            with open(bad, "w") as f:
+                # 'devices' must be an array; null is invalid per the schema.
+                json.dump({"cdiVersion": gen.CDI_VERSION,
+                           "kind": gen.CDI_VENDOR + "/bad",
+                           "devices": None}, f)
+            rc, out = self._validate_dir(d)
+            self.assertNotEqual(rc, 0,
+                                "cdi validate unexpectedly accepted a malformed spec:\n%s" % out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Written and published by Claude Sonnet 5

## Summary
Stacked on top of #34 (test suite) — this branch is `koen/cdi-test-suite` plus the commits below, so the diff currently includes #34's changes too. Once #34 merges into `main`, this PR's diff will shrink to show only the fixes below.

- **hookName casing**: the CDI schema requires the hook name field as `hookName` (camelCase); the generator emitted lowercase `hookname`, which only validated because Go's `encoding/json` matches keys case-insensitively. A strict validator or non-Go consumer would see the required field as missing.
- **Dedupe cdsp/adsp `-secure` handling**: the rule for attaching a cdsp/adsp node's `-secure` sibling was duplicated between the per-device and catch-all entries; extracted into a shared `node_paths()` helper. Output unchanged.
- **Remove legacy monolithic CDI file**: earlier versions wrote a single `qualcomm.json`; a leftover file after upgrading to the per-class layout was never cleaned up and could define stale/conflicting devices. Removed on regeneration (dry-run only reports it).
- **Scope hook node list to `--classes`**: `--classes` correctly filtered which CDI files were written, but the hook script's chmod list was still built from every class, so e.g. `--classes fastrpc-cdsp` still chmod'd render/video/dmaheap/adsp nodes the user excluded.

## Test plan
- [x] `python3 -m unittest discover -s tests -v` — all 18 tests pass (11 structural, 7 validation skipped without `cdi` on PATH)